### PR TITLE
Fix Vercel deployment and align local environment.

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,14 @@
+# Exclude large directories from Vercel deployment
+voices/
+samples/
+# Exclude docker-related files
+Dockerfile
+.dockerignore.in
+# Exclude git files
+.gitignore
+# Exclude development files
+requirements_dev.txt
+# Exclude other large directories that are not needed
+gruut/
+larynx/
+TTS/

--- a/app.py
+++ b/app.py
@@ -824,30 +824,10 @@ async def api_version():
 @app.route("/")
 async def app_index():
     """Test page."""
-    return await render_template(
-        "index.html",
-        default_language=_DEFAULT_LANGUAGE,
-        cache=args.cache,
-        preferred_voices=_VOICE_ALIASES.get(_DEFAULT_LANGUAGE, []),
-    )
+    # Serve the static index.html from the root directory
+    return await send_from_directory(str(_DIR), "index.html")
 
 
-@app.route("/css/<path:filename>", methods=["GET"])
-async def css(filename) -> Response:
-    """CSS static endpoint."""
-    return await send_from_directory("css", filename)
-
-
-@app.route("/js/<path:filename>", methods=["GET"])
-async def js(filename) -> Response:
-    """Javascript static endpoint."""
-    return await send_from_directory("js", filename)
-
-
-@app.route("/img/<path:filename>", methods=["GET"])
-async def img(filename) -> Response:
-    """Image static endpoint."""
-    return await send_from_directory("img", filename)
 
 
 # Swagger UI


### PR DESCRIPTION
This commit addresses two primary issues:
1. The Vercel deployment failing due to exceeding the 250MB size limit.
2. A discrepancy between the local development server and the Vercel deployment in which HTML file was being served.

Changes:
- A `.vercelignore` file is added to exclude large directories (`voices/`, `samples/`, `TTS/`, etc.) from the Vercel build, resolving the deployment size error.
- `app.py` is modified to serve the static `index.html` from the root directory, aligning the local server's behavior with the Vercel environment as defined in `vercel.json`.
- Unused static file routes (`/css`, `/js`, `/img`) are removed from `app.py` for code cleanliness, as the new frontend uses CDNs.